### PR TITLE
Remove exec-sync package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "main": "index.js",
   "dependencies": {
-    "exec-sync": "^0.1.6",
     "uuid": "^2.0.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iconutil",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Convert between PNG/Iconsets and .ICNS files",
   "author": {
     "name": "Will Franzen",


### PR DESCRIPTION
I couldn't install `iconutil`, npm always stopped with a bunch of errors. So I investigated a bit and it turned out that the fault was at a dependency of the `exec-sync` package.

However `iconutil` doesn't actually use `exec-sync` (anymore?), so all I had to do was to remove it from the package.json, and now the package works for me :)

I also bumped the version number so you can push the new version to NPM
