### PR TITLE
Fix warning 'Calling an asynchronous function without callback is deprecated'

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var rmdir = function(path) {
                 unlinked++;
 
                 if(unlinked == files.length) {
-                    fs.rmdir(path);
+                    fs.rmdir(path, function() {});
                 }
             });
         });


### PR DESCRIPTION
As `fs.rmdir()` is async function, and there is no callback assigned, there will be a deprecated warning under Node v7.

```bash
(node:66797) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
    at maybeCallback (fs.js:96:42)
    at Object.fs.rmdir (fs.js:810:14)
    at /Users/taowang/lab/node.js/zazu-file-finder/node_modules/iconutil/index.js:17:24
    at FSReqWrap.oncomplete (fs.js:112:15)
```

So, just fixed it by adding an empty function here.

Signed-off-by: Tao Wang <twang2218@gmail.com>